### PR TITLE
Corrected slider.itemW ignoring slideMargins

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -983,7 +983,7 @@
         slider.maxW = (maxItems) ? (maxItems * slider.itemT) - slideMargin : slider.w;
         slider.itemW = (slider.minW > slider.w) ? (slider.w - (slideMargin * (minItems - 1)))/minItems :
                        (slider.maxW < slider.w) ? (slider.w - (slideMargin * (maxItems - 1)))/maxItems :
-                       (slider.vars.itemWidth > slider.w) ? slider.w : slider.vars.itemWidth;
+                       (slider.vars.itemWidth > slider.w) ? slider.w : slider.itemT;
 
         slider.visible = Math.floor(slider.w/(slider.itemW));
         slider.move = (slider.vars.move > 0 && slider.vars.move < slider.visible ) ? slider.vars.move : slider.visible;


### PR DESCRIPTION
The current slider.itemW calculation didn't take slideMargin into account, resulting in the behaviour described in #1433.
